### PR TITLE
Updated libc6-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM perl:5-slim
 COPY . /home/joomscan
 WORKDIR /home/joomscan
 RUN adduser joomscan --disabled-password --disabled-login --gecos "" --no-create-home --home /home/joomscan && chown joomscan:joomscan /home/joomscan -R
-RUN apt-get update && apt-get install -y --no-install-recommends libc6-dev=2.24-11+deb9u3 gcc=4:6.3.0-4 && rm /var/lib/apt/lists/* -R && cpanm Bundle::LWP
+RUN apt-get update && apt-get install -y --no-install-recommends libc6-dev=2.24-11+deb9u4 gcc=4:6.3.0-4 && rm /var/lib/apt/lists/* -R && cpanm Bundle::LWP
 USER joomscan
 ENTRYPOINT ["perl", "joomscan.pl"]
 CMD ["-h"]


### PR DESCRIPTION
The package libc6-dev=2.24-11+deb9u3 is not available anymore and it fails to continue the building process:

E: Version '2.24-11+deb9u3' for 'libc6-dev' was not found
The command '/bin/sh -c apt-get update && apt-get install -y --no-install-recommends libc6-dev=2.24-11+deb9u3 gcc=4:6.3.0-4 && rm /var/lib/apt/lists/* -R && cpanm Bundle::LWP' returned a non-zero code: 100

Changing to version 2.24-11+deb9u4